### PR TITLE
fix: generation of secret and config file when not needed

### DIFF
--- a/charts/kubernetes-stateful-chart/Chart.yaml
+++ b/charts/kubernetes-stateful-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateful-chart
 description: A Generic Helm chart for a stateful Kubernetes application
 type: application
-version: 0.0.10
+version: 0.0.11
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateful-chart/templates/configuration/_helpers.tpl
+++ b/charts/kubernetes-stateful-chart/templates/configuration/_helpers.tpl
@@ -1,17 +1,6 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{/*
-Return a valid application configuration file.
-*/}}
-{{- define "app.configurationFile" -}}
-{{- if .Values.config }}
-{{- .Values.config }}
-{{- else }}
-{{- .Values.defaultConfig.config -}}
-{{- end }}
-{{- end }}
-
-{{/*
 Return a valid map of environment variables.
 
 Pre_condition:

--- a/charts/kubernetes-stateful-chart/templates/configuration/manifest.yaml
+++ b/charts/kubernetes-stateful-chart/templates/configuration/manifest.yaml
@@ -6,6 +6,7 @@ It relies on the HOCON notation.
 Ref: https://github.com/lightbend/config/blob/main/HOCON.md#hocon-human-optimized-config-object-notation.
 */}}
 {{- if .Values.include }}
+{{- if and .Values.defaultConfig.name .Values.defaultConfig.mountPath }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -16,8 +17,7 @@ metadata:
     {{- include "lib.labels" . | nindent 4 }}
   annotations: {{- include "lib.annotations" . | nindent 4 }}
 data:
-  {{- if .Values.defaultConfig.name }}
   {{ .Values.defaultConfig.name }}: |-
-    {{- tpl (include "app.configurationFile" $) $ | nindent 4 }}
-  {{- end }}
+    {{- tpl (default .Values.defaultConfig.config .Values.config) $ | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/kubernetes-stateful-chart/templates/configuration/secret.envs.yaml
+++ b/charts/kubernetes-stateful-chart/templates/configuration/secret.envs.yaml
@@ -8,6 +8,7 @@ a main container for providing environmental specifics configurations.
 Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#define-container-environment-variables-using-secret-data
 */}}
 {{- if .Values.include }}
+{{- if or .Values.envs .Values.additionalEnvs }}
 {{/* Note: .Values.additionalEnvs overwrite values in .Values.envs */}}
 {{- $envs := mergeOverwrite .Values.envs .Values.additionalEnvs -}}
 apiVersion: v1
@@ -23,4 +24,5 @@ metadata:
     {{- include "lib.annotations" . | indent 4 }}
 data:
   {{- include "app.renderEnvVars" (dict "envs" $envs "context" $) }}
+{{- end }}
 {{- end }}

--- a/charts/kubernetes-stateful-chart/templates/statefulset/_helpers.tpl
+++ b/charts/kubernetes-stateful-chart/templates/statefulset/_helpers.tpl
@@ -34,7 +34,9 @@ Return checksum of the secret with encoded environment variables
 */}}
 {{- define "app.envsChecksum" }}
 {{- if and (empty .Values.externalEnvSecret) (empty .Values.internalEnvSecret) }}
+{{- if or .Values.envs .Values.additionalEnvs }}
 checksum/envs: {{ include (print $.Template.BasePath "/configuration/secret.envs.yaml") . | sha256sum }}
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
+++ b/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
@@ -193,9 +193,11 @@ spec:
           command: {{ default .Values.entrypoint .Values.customEntrypoint | toYaml | nindent 12 }}
           args: {{ default .Values.args .Values.customArgs | toYaml | nindent 12 }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}
+          {{- if or .Values.envs .Values.additionalEnvs .Values.externalEnvSecret .Values.internalEnvSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "app.secretRef" . }}
+          {{- end }}
           ports:
           {{- .Values.ports | toYaml | nindent 12 }}
           {{/*
@@ -246,11 +248,9 @@ spec:
           */}}
           volumeMounts:
             {{- if and .Values.defaultConfig.mountPath .Values.defaultConfig.name }}
-            {{- if and .Values.defaultConfig.mountPath .Values.defaultConfig.name }}
             - mountPath: {{ .Values.defaultConfig.mountPath | quote }}
               name: conf
               subPath: {{ .Values.defaultConfig.name | quote }}
-            {{- end }}
             {{- end }}
             {{- $volumeMounts := concat .Values.volumes .Values.additionalVolumes }}
             {{- if $volumeMounts }}

--- a/charts/kubernetes-stateful-chart/tests/configuration/manifest_test.yaml
+++ b/charts/kubernetes-stateful-chart/tests/configuration/manifest_test.yaml
@@ -2,15 +2,14 @@ suite: app configuration
 templates:
   - configuration/manifest.yaml
 tests:
-  - it: should be created by default
+  - it: should not be created by default
     asserts:
       - hasDocuments:
-          count: 1
-      - isKind:
-          of: ConfigMap
+          count: 0
   - it: should generate a valid configuration file
     set:
       defaultConfig.name: app.conf
+      defaultConfig.mountPath: /home/app/server/app.conf
       defaultConfig.config: |-
         ktor {
           environment = production
@@ -26,6 +25,7 @@ tests:
   - it: should overwrite the default configuration file
     set:
       defaultConfig.name: app.conf
+      defaultConfig.mountPath: /home/app/server/app.conf
       defaultConfig.config: |-
         ktor {
           environment = production

--- a/charts/kubernetes-stateful-chart/tests/configuration/secret_envs_test.yaml
+++ b/charts/kubernetes-stateful-chart/tests/configuration/secret_envs_test.yaml
@@ -4,6 +4,10 @@ templates:
 release:
   name: test-release
 tests:
+  - it: should not be created by default
+    asserts:
+      - hasDocuments:
+          count: 0
   - it: should contain a unique set of environment variables
     set:
       envs:

--- a/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
+++ b/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
@@ -373,6 +373,8 @@ tests:
       include: true
       fullnameOverride: app
       name: packages
+      envs:
+        EXAMPLE: "example"
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].envFrom[0].secretRef.name


### PR DESCRIPTION
# Pull Request Template

## Description

This PR improves the `kubernetes-stateful-chart`.

Before this contribution, the stateful chart generated empty secret object for environment variables and empty configmap for the application.
This is not expected behavior, because if fields are missing the ConfigMap and Secret objects should not be created.
Also, if these objects are missing, the stateful set manifest must avoid referencing them.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?


- fine-tuned the `tests/configuration`;
- fine-tuned the `tests/statefulset`. 

## Additional Information

There are stateful apps for which there is no need to specify a default configuration file as part of the application deployment specification. 
