### PR TITLE
fix: the reference to non existent conf configmap volume

### DIFF
--- a/charts/kubernetes-stateful-chart/Chart.yaml
+++ b/charts/kubernetes-stateful-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateful-chart
 description: A Generic Helm chart for a stateful Kubernetes application
 type: application
-version: 0.0.11
+version: 0.0.12
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
+++ b/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
@@ -295,9 +295,11 @@ spec:
         - nfs: an NFS mount on the host that shares a pod's lifetime;
       */}}
       volumes:
+        {{- if and .Values.defaultConfig.mountPath .Values.defaultConfig.name }}
         - name: conf
           configMap:
             name: {{ include "lib.appName" . }}-conf
+        {{- end }}
         {{- $volumes := concat .Values.volumes .Values.additionalVolumes }}
         {{- if $volumes }}
         {{- range $volume := $volumes }}

--- a/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
+++ b/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
@@ -44,6 +44,9 @@ tests:
       - equal:
           path: spec.podManagementPolicy
           value: OrderedReady
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 1
     template: statefulset/manifest.yaml
   - it: should be created with the full configuration
     set:
@@ -406,12 +409,6 @@ tests:
     asserts:
       - isNotNull:
           path: spec.template.spec.volumes
-      - contains:
-          path: spec.template.spec.volumes
-          content:
-            configMap:
-              name: unittest-kubernetes-stateful-chart-app-conf
-            name: conf
       - contains:
           path: spec.template.spec.volumes
           content:


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the following issue, by default, the following volume was referenced by the StateFulSet object:

```
  - configMap:
      name: SOME-PREFIX-conf
    name: conf
```

This configuration is not part of the default configuration anymore and should be removed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

- Added an assertion to this unit test: `should be created by default with very minimal configuration`.
