### PR TITLE
feat(kubernetes-stateless-chart): add support for multiple additional external secrets

### DIFF
--- a/charts/kubernetes-stateless-chart/Chart.yaml
+++ b/charts/kubernetes-stateless-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateless-chart
 description: A Generic Helm chart for a stateless Kubernetes application
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateless-chart/README.md
+++ b/charts/kubernetes-stateless-chart/README.md
@@ -153,12 +153,13 @@ Checkout the [release.json](./release.json) for details about where the chart is
 
 ### Application environment variables
 
-| Name                | Description                                                                 | Value |
-| ------------------- | --------------------------------------------------------------------------- | ----- |
-| `envs`              | Environment variables                                                       | `{}`  |
-| `additionalEnvs`    | Additional environment variables                                            | `{}`  |
-| `internalEnvSecret` | Specify the internal secret name that contains system environment variables | `""`  |
-| `externalEnvSecret` | Specify the external secret name that contains system environment variables | `""`  |
+| Name                           | Description                                                                                     | Value |
+| ------------------------------ | ----------------------------------------------------------------------------------------------- | ----- |
+| `envs`                         | Environment variables                                                                           | `{}`  |
+| `additionalEnvs`               | Additional environment variables                                                                | `{}`  |
+| `internalEnvSecret`            | Specify the internal secret name that contains system environment variables                     | `""`  |
+| `externalEnvSecret`            | Specify the external secret name that contains system environment variables                     | `""`  |
+| `additionalExternalEnvSecrets` | Specify additional external secrets' names as strings that contain system environment variables | `[]`  |
 
 ### Application Kubernetes resources
 

--- a/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
+++ b/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
@@ -35,10 +35,10 @@ References:
 {{/*
 Internal variables for normalizing the external user input.
 - Use *mergeOverwrite* function to join together maps.
-- Use *concat* function to join together array lists.
+- Use *concat* function to join together lists.
 */}}
-{{- $sidecars := concat .Values.sidecars .Values.additionalSidecars  -}}
-{{- $initContainers := concat list .Values.initContainers .Values.additionalInitContainers | uniq -}}
+{{- $sidecars := concat .Values.sidecars .Values.additionalSidecars | uniq  -}}
+{{- $initContainers := concat .Values.initContainers .Values.additionalInitContainers | uniq -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -224,6 +224,12 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "app.secretRef" . }}
+            {{- with .Values.additionalExternalEnvSecrets }}
+            {{- range . }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
           ports:
           {{- .Values.ports | toYaml | nindent 12 }}
           {{/*

--- a/charts/kubernetes-stateless-chart/tests/deployment/manifest_test.yaml
+++ b/charts/kubernetes-stateless-chart/tests/deployment/manifest_test.yaml
@@ -802,3 +802,23 @@ tests:
         - lengthEqual:
             path: spec.template.spec.containers[0].volumeMounts
             count: 2
+  - it: should reference additionalExternalEnvSecrets
+    set:
+      additionalExternalEnvSecrets:
+        - "external-secret-1"
+        - "external-secret-2"
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].envFrom
+      - lengthEqual:
+          path: spec.template.spec.containers[0].envFrom
+          count: 3
+      - isSubset:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef
+          content:
+              name: external-secret-1
+      - isSubset:
+          path: spec.template.spec.containers[0].envFrom[2].secretRef
+          content:
+            name: external-secret-2
+    template: deployment/manifest.yaml

--- a/charts/kubernetes-stateless-chart/values.schema.json
+++ b/charts/kubernetes-stateless-chart/values.schema.json
@@ -614,6 +614,12 @@
             "description": "Specify the external secret name that contains system environment variables",
             "default": ""
         },
+        "additionalExternalEnvSecrets": {
+            "type": "array",
+            "description": "Specify additional external secrets' names as strings that contain system environment variables",
+            "default": [],
+            "items": {}
+        },
         "kubernetesYamlResources": {
             "type": "array",
             "description": "Kubernetes objects to add to the application package",

--- a/charts/kubernetes-stateless-chart/values.yaml
+++ b/charts/kubernetes-stateless-chart/values.yaml
@@ -566,6 +566,10 @@ internalEnvSecret: ""
 ## leaked in the deployment version of the values.yaml file.
 ## Note: envs, additionalEnvs will be ignored when externalEnvSecret is set
 externalEnvSecret: ""
+## @param additionalExternalEnvSecrets Specify additional external secrets' names as strings that contain system environment variables
+## This secret contains a valid set of environment variables that are compatible with the main application.
+## Note: this secret will be added as an additional secret reference to the main application.
+additionalExternalEnvSecrets: []
 ## @section Application Kubernetes resources
 ##
 ## @param kubernetesYamlResources Kubernetes objects to add to the application package


### PR DESCRIPTION
## Description

I as a User of the `kubernetes-stateless-chart` I  want to be able to specify environment
variables in multiple external secret objects such that I can implement my own management procedure on top and better integrate with Operators for secrets management like [external-secrets](https://external-secrets.io/latest/).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

There are new Unit Tests to showcase how the feature works and this change is backwards compatible. Notice that even if the feature is not used, all tests are green anyway.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
