### PR TITLE
feat(kubernetes-stateless-chart/kubernetes-stateful-chart): enable the support for multiple external secrets

### DIFF
--- a/charts/kubernetes-stateful-chart/Chart.yaml
+++ b/charts/kubernetes-stateful-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateful-chart
 description: A Generic Helm chart for a stateful Kubernetes application
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
+++ b/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
@@ -19,8 +19,6 @@ Internal variables for normalizing the external user input.
 - Use *mergeOverwrite* function to join together maps.
 - Use *concat* function to join together array lists.
 */}}
-{{- $sidecars := concat .Values.sidecars .Values.additionalSidecars  -}}
-{{- $initContainers := concat .Values.initContainers .Values.additionalInitContainers | uniq -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -157,6 +155,7 @@ spec:
       securityContext:
         {{- .Values.podSecurityContext | toYaml | nindent 8 }}
       {{- end -}}
+      {{- $initContainers := concat .Values.initContainers .Values.additionalInitContainers | uniq -}}
       {{- if $initContainers }}
       {{/*
           List of initialization containers belonging to the pod.
@@ -197,6 +196,12 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ include "app.secretRef" . }}
+            {{- with .Values.additionalExternalEnvSecrets }}
+            {{- range . }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+            {{- end }}
           {{- end }}
           ports:
           {{- .Values.ports | toYaml | nindent 12 }}
@@ -264,6 +269,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- include "app.volumeMountsFromVolumeClaims" . | nindent 12 }}
+        {{- $sidecars := concat .Values.sidecars .Values.additionalSidecars  -}}
         {{- if $sidecars }}
         {{/*
             List of containers belonging to the pod.

--- a/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
+++ b/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
@@ -8,6 +8,7 @@ templates:
   - configuration/secret.envs.yaml
 tests:
   - it: should be created by default with very minimal configuration
+    template: statefulset/manifest.yaml
     asserts:
       - hasDocuments:
           count: 1
@@ -47,7 +48,6 @@ tests:
       - equal:
           path: spec.template.spec.volumes
           value: null
-    template: statefulset/manifest.yaml
   - it: should be created with the full configuration
     set:
       namespaceOverride: kube-app
@@ -874,3 +874,30 @@ tests:
       - lengthEqual:
             path: spec.template.spec.containers[0].volumeMounts
             count: 2
+  - it: should reference additionalExternalEnvSecrets
+    template:  statefulset/manifest.yaml
+    set:
+      envs:
+        INTERNAL_URL: "http://unittest-kubernetes-stateful-chart-packages:9084"
+      additionalExternalEnvSecrets:
+        - "external-secret-1"
+        - "external-secret-2"
+    asserts:
+      - isNotNull:
+          path: spec.template.spec.containers[0].envFrom
+      - lengthEqual:
+          path: spec.template.spec.containers[0].envFrom
+          count: 3
+      - isSubset:
+          path: spec.template.spec.containers[0].envFrom[1].secretRef
+          content:
+            name: external-secret-1
+      - isSubset:
+          path: spec.template.spec.containers[0].envFrom[2].secretRef
+          content:
+            name: external-secret-2
+  - it: should not reference any secret object by default
+    template:  statefulset/manifest.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].envFrom

--- a/charts/kubernetes-stateful-chart/values.yaml
+++ b/charts/kubernetes-stateful-chart/values.yaml
@@ -576,6 +576,10 @@ internalEnvSecret: ""
 ## leaked in the deployment version of the values.yaml file.
 ## Note: envs, additionalEnvs will be ignored when externalEnvSecret is set
 externalEnvSecret: ""
+## @param additionalExternalEnvSecrets Specify additional external secrets' names as strings that contain system environment variables
+## This secret contains a valid set of environment variables that are compatible with the main application.
+## Note: this secret will be added as an additional secret reference to the main application.
+additionalExternalEnvSecrets: []
 ## @section Application Kubernetes resources
 ##
 ## @param kubernetesYamlResources Kubernetes objects to add to the application package

--- a/charts/kubernetes-stateless-chart/Chart.yaml
+++ b/charts/kubernetes-stateless-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateless-chart
 description: A Generic Helm chart for a stateless Kubernetes application
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
+++ b/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
@@ -221,6 +221,7 @@ spec:
           command: {{ default .Values.entrypoint .Values.customEntrypoint | toYaml | nindent 12 }}
           args: {{ default .Values.args .Values.customArgs | toYaml | nindent 12 }}
           securityContext: {{ .Values.containerSecurityContext | toYaml | nindent 12 }}
+          {{- if or .Values.envs .Values.additionalEnvs .Values.externalEnvSecret .Values.internalEnvSecret }}
           envFrom:
             - secretRef:
                 name: {{ include "app.secretRef" . }}
@@ -230,6 +231,7 @@ spec:
                 name: {{ . }}
             {{- end }}
             {{- end }}
+          {{- end }}
           ports:
           {{- .Values.ports | toYaml | nindent 12 }}
           {{/*

--- a/charts/kubernetes-stateless-chart/tests/deployment/manifest_test.yaml
+++ b/charts/kubernetes-stateless-chart/tests/deployment/manifest_test.yaml
@@ -350,6 +350,9 @@ tests:
       include: true
       fullnameOverride: app
       name: packages
+      envs:
+        INTERNAL_URL: "http://unittest-kubernetes-stateless-chart-packages:9084"
+        EXTERNAL_URL: "https://packages.app.local"
     asserts:
       - isNotNull:
           path: spec.template.spec.containers[0].envFrom[0].secretRef.name
@@ -804,6 +807,8 @@ tests:
             count: 2
   - it: should reference additionalExternalEnvSecrets
     set:
+      envs:
+        INTERNAL_URL: "http://unittest-kubernetes-chart:9084"
       additionalExternalEnvSecrets:
         - "external-secret-1"
         - "external-secret-2"
@@ -822,3 +827,8 @@ tests:
           content:
             name: external-secret-2
     template: deployment/manifest.yaml
+  - it: should not reference any secret object by default
+    template:  deployment/manifest.yaml
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].envFrom


### PR DESCRIPTION
## Description

This pull request adds support to multiple secret objects for `kubernetes-stateless-chart` and `kubernetes-stateful-chart`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

For each chart added unit tests and made sure that the change is backward compatible.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
