### PR TITLE
fix(kubernetes-stateless-chart): allow to set Deployment.revisionHis…

### DIFF
--- a/charts/kubernetes-stateless-chart/Chart.yaml
+++ b/charts/kubernetes-stateless-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateless-chart
 description: A Generic Helm chart for a stateless Kubernetes application
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
+++ b/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
@@ -110,6 +110,12 @@ spec:
   strategy: {{- include "app.deploymentStrategy" .  | nindent 4 }}
   replicas: {{ .Values.replicaCount }}
   {{/*
+    revisionHistoryLimit is the maximum number of revisions that will be maintained in the Deployment's revision history.
+    The revision history consists of all revisions not represented by a currently applied StatefulSetSpec version.
+    The default value is 10.
+  */}}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{/*
     PodTemplateSpec describes the data a pod should have when created from a template.
     In short this is a wrapper for the PodSpec object. The PodSpec represents the actual
     specification of the desired behaviour of the pod.


### PR DESCRIPTION
## Description

The documentation describes revisionHistoryLimit, but it does not work. Change the deployment template to allow setting Deployment.revisionHistoryLimit.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
