### PR TITLE
feat: allow helm templating for image spec

### DIFF
--- a/charts/kubernetes-stateful-chart/Chart.yaml
+++ b/charts/kubernetes-stateful-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateful-chart
 description: A Generic Helm chart for a stateful Kubernetes application
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
+++ b/charts/kubernetes-stateful-chart/templates/statefulset/manifest.yaml
@@ -187,7 +187,7 @@ spec:
       {{- end }}
       containers:
         - name: app
-          image: {{ include "lib.image" (dict "registry" .Values.image.registry "repository" .Values.image.repository "tag" .Values.image.tag ) }}
+          image: {{ tpl (include "lib.image" (dict "registry" .Values.image.registry "repository" .Values.image.repository "tag" .Values.image.tag )) $ }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{ default .Values.entrypoint .Values.customEntrypoint | toYaml | nindent 12 }}
           args: {{ default .Values.args .Values.customArgs | toYaml | nindent 12 }}

--- a/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
+++ b/charts/kubernetes-stateful-chart/tests/statefulset/manifest_test.yaml
@@ -900,3 +900,32 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].envFrom
+  - it: should return default values for image spec
+    template: statefulset/manifest.yaml
+    set:
+      include: true # This is default
+      name: sample # Overwrite the app name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "quay.io/jetbrains/run-forever:v0.1.0"
+  - it: should allow helm templating for image spec
+    template: statefulset/manifest.yaml
+    set:
+      include: true # This is default
+      name: sample # Overwrite the app name
+      image.registry: "{{ print \"unittest_registry\" }}"
+      image.repository: "{{ print \"unittest_repository\" }}"
+      image.tag: "{{ print \"v99.99.99\" }}"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: StatefulSet
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "unittest_registry/unittest_repository:v99.99.99"

--- a/charts/kubernetes-stateless-chart/Chart.yaml
+++ b/charts/kubernetes-stateless-chart/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kubernetes-stateless-chart
 description: A Generic Helm chart for a stateless Kubernetes application
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: 1.0.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/

--- a/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
+++ b/charts/kubernetes-stateless-chart/templates/deployment/manifest.yaml
@@ -222,7 +222,7 @@ spec:
       {{- end }}
       containers:
         - name: app
-          image: {{ include "lib.image" (dict "registry" .Values.image.registry "repository" .Values.image.repository "tag" .Values.image.tag ) }}
+          image: {{ tpl (include "lib.image" (dict "registry" .Values.image.registry "repository" .Values.image.repository "tag" .Values.image.tag )) $ }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{ default .Values.entrypoint .Values.customEntrypoint | toYaml | nindent 12 }}
           args: {{ default .Values.args .Values.customArgs | toYaml | nindent 12 }}

--- a/charts/kubernetes-stateless-chart/tests/deployment/manifest_test.yaml
+++ b/charts/kubernetes-stateless-chart/tests/deployment/manifest_test.yaml
@@ -844,3 +844,32 @@ tests:
     asserts:
       - isNull:
           path: spec.template.spec.containers[0].envFrom
+  - it: should return default values for image spec
+    template: deployment/manifest.yaml
+    set:
+      include: true # This is default
+      name: sample # Overwrite the app name
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "quay.io/jetbrains/run-forever:v0.1.0"
+  - it: should allow helm templating for image spec
+    template: deployment/manifest.yaml
+    set:
+      include: true # This is default
+      name: sample # Overwrite the app name
+      image.registry: "{{ print \"unittest_registry\" }}"
+      image.repository: "{{ print \"unittest_repository\" }}"
+      image.tag: "{{ print \"v99.99.99\" }}"
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "unittest_registry/unittest_repository:v99.99.99"


### PR DESCRIPTION
## Description

The change allows using Helm templating for image specs.

Example of use:
```
image:
  registry: "{{ .Values.global.image.registry }}"
  repository: "{{ .Values.global.image.repository }}"
  tag: "{{ .Values.global.image.tag }}"
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

- Test A
- Test B

## Checklist:

- [ ] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings.
- [ ] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [ ] I have tested my changes on a live Kubernetes cluster.

## Additional Information

Any additional information or context to provide reviewers of this pull request.

## Screenshots

If you have added any visual changes, please add screenshots here to demonstrate them.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
