### PR TITLE
feat(charts): [kubernetes-manifests] add the first version

### DIFF
--- a/charts/kubernetes-manifests/.helmignore
+++ b/charts/kubernetes-manifests/.helmignore
@@ -1,0 +1,61 @@
+# Remove release files
+release.json
+# Remove ignore files
+.gitignore
+.helmignore
+
+# Remove all shell scripts
+*.sh
+
+# Remove all resulting packages
+./*.tgz
+./.
+./..
+.cache
+# Just in case if someone forgets to remove their local.properties file
+*.properties
+
+# Internal cluster values
+values/
+
+# Rendered templates
+rendered/
+
+# Got it from the Internet
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/
+.helm-docs
+.helm_output
+*.md
+.env
+Makefile
+*.lock
+examples/
+unittests/
+tests/
+values.schema.json
+schema.values.json
+# Docs related
+#README.md
+LICENSE
+
+ct.yaml

--- a/charts/kubernetes-manifests/Chart.yaml
+++ b/charts/kubernetes-manifests/Chart.yaml
@@ -1,0 +1,16 @@
+apiVersion: v2
+name: kubernetes-manifests
+description: A Generic Helm chart for packaging Kubernetes manifests
+type: application
+version: 1.0.0
+appVersion: 1.0.0
+icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
+home: https://jetbrains.com/
+annotations:
+  category: Infrastructure
+keywords:
+  - jetbrains
+  - template
+maintainers:
+  - name: JetBrains
+    url: https://www.jetbrains.com/support

--- a/charts/kubernetes-manifests/Makefile
+++ b/charts/kubernetes-manifests/Makefile
@@ -1,0 +1,3 @@
+include ../../lib/Makefiles/Helm.mk
+
+

--- a/charts/kubernetes-manifests/README.md
+++ b/charts/kubernetes-manifests/README.md
@@ -1,0 +1,48 @@
+# Kubernetes Manifests
+
+`kubernetes-manifests` is a generic Helm chart to use for the packaging of ad-hoc Kubernetes manifests in one bundle.
+
+## Use Cases
+
+Use this chart to package Kubernetes manifests that are not part of a Helm chart during a Helm to deploy in Kubernetes,
+and the main application chart does not include a parameter in the values.yaml for passing custom Kubernetes manifests.
+
+## How to use this chart
+
+This chart is formatted as an OCI package. Include it as a dependency from `https://public.jetbrains.space/p/helm/packages/container/library`.
+
+Add it to your Chart.yaml file of your Helm package.
+
+```yaml
+dependencies:
+  - name: kubernetes-manifests
+    repository: oci://public.registry.jetbrains.space/p/helm/library
+    version: 1.x.x
+    alias: app
+```
+
+## Repository
+
+Checkout the [release.json](release.json) for details about where the chart is hosted.
+
+## Prerequisites
+
+- Kubernetes 1.24+;
+
+- Helm 3+.
+
+## Parameters
+
+### Global parameters
+
+| Name      | Description                                                 | Value  |
+| --------- | ----------------------------------------------------------- | ------ |
+| `global`  | Provide a map of global values to be used in the templates  | `{}`   |
+| `include` | Includes/Excludes the manifests packaged by this Helm chart | `true` |
+
+### Manifests to package
+
+| Name                                | Description                                             | Value |
+| ----------------------------------- | ------------------------------------------------------- | ----- |
+| `kubernetesYamlResources`           | Kubernetes objects to add to the package                | `[]`  |
+| `additionalKubernetesYamlResources` | Add additional Kubernetes objects to add to the package | `[]`  |

--- a/charts/kubernetes-manifests/release.json
+++ b/charts/kubernetes-manifests/release.json
@@ -1,0 +1,19 @@
+{
+  "metadata": {
+    "name": "kubernetes-manifests",
+    "description": "Find more details about this chart in its Chart.yaml file."
+  },
+  "spec": {
+    "repositories": [
+      {
+        "name": "helm-library",
+        "description": "Repository for Kubernetes charts",
+        "url": "public.registry.jetbrains.space/p/helm/library",
+        "type": "oci",
+        "env": {
+          "nameSelector": "HELM_CHARTS_REGISTRY"
+        }
+      }
+    ]
+  }
+}

--- a/charts/kubernetes-manifests/templates/NOTES.txt
+++ b/charts/kubernetes-manifests/templates/NOTES.txt
@@ -1,0 +1,4 @@
+kubernetes-manifests
+====================
+Chart Version: {{ .Chart.Version }}
+Support contact: it is outlined in the Chart.yaml file

--- a/charts/kubernetes-manifests/templates/kubernetesresources/manifest.yaml
+++ b/charts/kubernetes-manifests/templates/kubernetesresources/manifest.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.include -}}
+{{- $kubernetesResources := concat .Values.kubernetesYamlResources .Values.additionalKubernetesYamlResources -}}
+{{- if $kubernetesResources -}}
+apiVersion: v1
+kind: List
+items:
+{{- tpl ($kubernetesResources | toYaml) $ | nindent 4 }}
+{{- end -}}
+{{- end -}}

--- a/charts/kubernetes-manifests/tests/kubernetesresources/mainfest_test.yaml
+++ b/charts/kubernetes-manifests/tests/kubernetesresources/mainfest_test.yaml
@@ -1,0 +1,85 @@
+suite: app kubernetes resources
+templates:
+  - kubernetesresources/manifest.yaml
+tests:
+  - it: should not be created by default
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not be generated when include is set to false
+    set:
+      include: false
+      kubernetesYamlResources:
+        - apiVersion: v1
+          kind: Nameapp
+          metadata:
+            name: kong
+            labels:
+              app: kong
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should allow to compose a set of custom YAML objects
+    set:
+        kubernetesYamlResources:
+          - apiVersion: v1
+            kind: Nameapp
+            metadata:
+              name: kong
+              labels:
+                app: kong
+          - apiVersion: v1
+            kind: ServiceAccount
+            metadata:
+              nameapp: kong
+              name: kong
+              labels:
+                app: kong
+        additionalKubernetesYamlResources:
+          - apiVersion: autoscaling/v1
+            kind: HorizontalPodAutoscaler
+            metadata:
+              name: kong-apigateway-weu-dev-ha
+              nameapp: kong
+              labels:
+                app: kong
+            spec:
+              scaleTargetRef:
+                apiVersion: apps/v1
+                kind: Deployment
+                name: kong-apigateway-weu-dev
+              minReplicas: 1
+              maxReplicas: 7
+              targetCPUUtilizationPercentage: 71
+    asserts:
+      - equal:
+          path: items
+          value:
+            - apiVersion: v1
+              kind: Nameapp
+              metadata:
+                labels:
+                  app: kong
+                name: kong
+            - apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                labels:
+                  app: kong
+                name: kong
+                nameapp: kong
+            - apiVersion: autoscaling/v1
+              kind: HorizontalPodAutoscaler
+              metadata:
+                labels:
+                  app: kong
+                name: kong-apigateway-weu-dev-ha
+                nameapp: kong
+              spec:
+                maxReplicas: 7
+                minReplicas: 1
+                scaleTargetRef:
+                  apiVersion: apps/v1
+                  kind: Deployment
+                  name: kong-apigateway-weu-dev
+                targetCPUUtilizationPercentage: 71

--- a/charts/kubernetes-manifests/values.schema.json
+++ b/charts/kubernetes-manifests/values.schema.json
@@ -1,0 +1,28 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {
+        "global": {
+            "type": "object",
+            "description": "Provide a map of global values to be used in the templates",
+            "default": {}
+        },
+        "include": {
+            "type": "boolean",
+            "description": "Includes/Excludes the manifests packaged by this Helm chart",
+            "default": true
+        },
+        "kubernetesYamlResources": {
+            "type": "array",
+            "description": "Kubernetes objects to add to the package",
+            "default": [],
+            "items": {}
+        },
+        "additionalKubernetesYamlResources": {
+            "type": "array",
+            "description": "Add additional Kubernetes objects to add to the package",
+            "default": [],
+            "items": {}
+        }
+    }
+}

--- a/charts/kubernetes-manifests/values.yaml
+++ b/charts/kubernetes-manifests/values.yaml
@@ -1,0 +1,46 @@
+##
+## This is a YAML-formatted file.
+##
+
+## @section Global parameters
+##
+## @param global Provide a map of global values to be used in the templates
+global: {}
+
+
+## @param include Includes/Excludes the manifests packaged by this Helm chart
+##
+include: true
+## @section Manifests to package
+##
+## @param kubernetesYamlResources Kubernetes objects to add to the package
+##
+## Example:
+## - apiVersion: v1
+##   kind: ServiceAccount
+##   metadata:
+##     namespace: '{{ .Release.namespace }}'
+##     name: '{{ include "lib.appName" . }}'-newsa
+##     labels:
+##       app.kubernetes.io/component: '{{ include "lib.componentName" . }}'
+##       '{{- include "lib.labels" . | nindent 4 }}'
+##
+kubernetesYamlResources: []
+## @param additionalKubernetesYamlResources Add additional Kubernetes objects to add to the package
+##
+## Example:
+## - apiVersion: v1
+##   kind: ResourceQuota
+##   metadata:
+##     name: '{{ include "lib.appName" $ }}'
+##     namespace: '{{ include "lib.namespace" $ }}'
+##     labels:
+##       app.kubernetes.io/component: '{{ include "lib.componentName" $ }}'
+##   spec:
+##     hard:
+##       requests.cpu: "4"
+##       requests.memory: 4Gi
+##       limits.cpu: "4"
+##       limits.memory: 4Gi
+##
+additionalKubernetesYamlResources: []


### PR DESCRIPTION
## Description

This PR adds a new chart `kubernetes-manifests` that allows packaging together in one bundle a group of manifests
in the case where it is not possible to add these manifests to the main application chart. 

You can use this chart when deploying some application Helm package to Kubernetes with Terraform; and the main chart does not support custom resources.  This chart allows the packaging of many manifests together and deploy in the same way as the main chart.  

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

The chart includes a small battery of tests.

## Checklist:

- [X] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation (if applicable).
- [X] My changes generate no new warnings.
- [X] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [X] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [X] I have tested my changes on a live Kubernetes cluster.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
