### PR TITLE
feat(charts): add kube-gatekeeper Helm chart with initial configuration and documentation

### DIFF
--- a/charts/kube-gatekeeper/.helmignore
+++ b/charts/kube-gatekeeper/.helmignore
@@ -1,0 +1,16 @@
+# Dependencies (run helm dependency update to fetch)
+charts/
+*.tgz
+Chart.lock
+# Ignore files
+.git/
+.gitignore
+.helmignore
+.DS_Store
+*.swp
+*.bak
+*.tmp
+*~
+.idea/
+.vscode/
+*.md

--- a/charts/kube-gatekeeper/Chart.yaml
+++ b/charts/kube-gatekeeper/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: kube-gatekeeper
+description: A Helm chart for OPA Gatekeeper policy enforcement in Kubernetes
+type: application
+version: 3.22.0-beta.0
+appVersion: v3.22.0-beta.0
+icon: https://open-policy-agent.github.io/gatekeeper/website/img/logo.svg
+home: https://github.com/open-policy-agent/gatekeeper
+annotations:
+  category: Infrastructure
+keywords:
+  - jetbrains
+  - gatekeeper
+  - open-policy-agent
+  - opa
+  - policy
+maintainers:
+  - name: JetBrains
+    url: https://www.jetbrains.com/support
+dependencies:
+  - name: gatekeeper
+    alias: spec
+    repository: https://open-policy-agent.github.io/gatekeeper/charts
+    version: 3.22.0-beta.0

--- a/charts/kube-gatekeeper/Makefile
+++ b/charts/kube-gatekeeper/Makefile
@@ -1,0 +1,1 @@
+include ../../lib/Makefiles/Helm.mk

--- a/charts/kube-gatekeeper/README.md
+++ b/charts/kube-gatekeeper/README.md
@@ -1,0 +1,43 @@
+# kube-gatekeeper
+
+This chart wraps the official [Gatekeeper](https://github.com/open-policy-agent/gatekeeper) Helm chart from the Open Policy Agent project.
+
+_Gatekeeper is a policy controller for Kubernetes that enforces custom resource-based policies (Constraint Templates and Constraints) and validates admission requests._
+
+## Source
+
+- **Upstream chart:** [open-policy-agent/gatekeeper](https://github.com/open-policy-agent/gatekeeper) — `charts/gatekeeper`
+- **Helm repository:** https://open-policy-agent.github.io/gatekeeper/charts
+
+## Prerequisites
+
+- Kubernetes 1.21+
+- Helm 3+
+
+## Install
+
+Add the JetBrains Helm repo (or use the chart from this repo), then:
+
+```bash
+helm dependency update
+helm install gatekeeper . -n gatekeeper-system --create-namespace
+```
+
+## Documentation
+
+- [Gatekeeper docs](https://open-policy-agent.github.io/gatekeeper/website/docs/)
+- [Upstream chart README](https://github.com/open-policy-agent/gatekeeper/tree/master/charts/gatekeeper)
+
+## Configuration
+
+All upstream Gatekeeper options are supported under the `spec` key in [values.yaml](./values.yaml). See the [upstream values](https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml) for the full list.
+
+Common overrides:
+
+- `spec.replicas` — number of Gatekeeper controller replicas
+- `spec.image.repository` / `spec.image.tag` — controller image
+- `spec.controllerManager.resources` — resource requests/limits
+- `spec.pdb.controllerManager.minAvailable` — PodDisruptionBudget
+
+## Parameters
+

--- a/charts/kube-gatekeeper/release.json
+++ b/charts/kube-gatekeeper/release.json
@@ -1,0 +1,1 @@
+{"metadata":{"name":"kube-gatekeeper","description":"Find more details about this chart in its Chart.yaml file."},"spec":{"repositories":[{"name":"library","description":"Repository for Kubernetes charts","url":"registry.jetbrains.team/p/helm/library","type":"oci","env":{"nameSelector":"HELM_CHARTS_REGISTRY_2"}}]}}

--- a/charts/kube-gatekeeper/values.schema.json
+++ b/charts/kube-gatekeeper/values.schema.json
@@ -1,0 +1,5 @@
+{
+    "title": "Chart Values",
+    "type": "object",
+    "properties": {}
+}

--- a/charts/kube-gatekeeper/values.yaml
+++ b/charts/kube-gatekeeper/values.yaml
@@ -1,0 +1,340 @@
+## @param spec Gatekeeper configuration (passed to upstream chart)
+## @skip spec
+## Replicates defaults from https://github.com/open-policy-agent/gatekeeper/blob/master/charts/gatekeeper/values.yaml
+spec:
+  replicas: 3
+  revisionHistoryLimit: 10
+  auditInterval: 60
+  metricsBackends: ["prometheus"]
+  auditMatchKindOnly: false
+  constraintViolationsLimit: 20
+  auditFromCache: false
+  disableAudit: false
+  disableMutation: false
+  disableValidatingWebhook: false
+  validatingWebhookName: gatekeeper-validating-webhook-configuration
+  validatingWebhookTimeoutSeconds: 3
+  validatingWebhookFailurePolicy: Ignore
+  validatingWebhookAnnotations: {}
+  validatingWebhookExemptNamespacesLabels: {}
+  validatingWebhookObjectSelector: {}
+  validatingWebhookMatchConditions: []
+  validatingWebhookCheckIgnoreFailurePolicy: Fail
+  validatingWebhookCustomRules: {}
+  validatingWebhookSubResources: ['pods/ephemeralcontainers', 'pods/exec', 'pods/log', 'pods/eviction', 'pods/portforward', 'pods/proxy', 'pods/attach', 'pods/binding', 'pods/resize', 'deployments/scale', 'replicasets/scale', 'statefulsets/scale', 'replicationcontrollers/scale', 'services/proxy', 'nodes/proxy', 'services/status']
+  validatingWebhookURL: null
+  validatingWebhookScope: '*'
+  enableDeleteOperations: false
+  enableConnectOperations: false
+  enableExternalData: true
+  enableGeneratorResourceExpansion: true
+  enableTLSHealthcheck: false
+  maxServingThreads: -1
+  mutatingWebhookName: gatekeeper-mutating-webhook-configuration
+  mutatingWebhookFailurePolicy: Ignore
+  mutatingWebhookReinvocationPolicy: Never
+  mutatingWebhookAnnotations: {}
+  mutatingWebhookExemptNamespacesLabels: {}
+  mutatingWebhookObjectSelector: {}
+  mutatingWebhookMatchConditions: []
+  mutatingWebhookTimeoutSeconds: 1
+  mutatingWebhookCustomRules: {}
+  mutatingWebhookSubResources: ['pods/ephemeralcontainers', 'pods/exec', 'pods/log', 'pods/eviction', 'pods/portforward', 'pods/proxy', 'pods/attach', 'pods/binding', 'deployments/scale', 'replicasets/scale', 'statefulsets/scale', 'replicationcontrollers/scale', 'services/proxy', 'nodes/proxy', 'services/status']
+  mutatingWebhookURL: null
+  mutatingWebhookScope: '*'
+  mutationAnnotations: false
+  auditChunkSize: 500
+  logLevel: INFO
+  logDenies: false
+  logMutations: false
+  admissionEventsInvolvedNamespace: false
+  auditEventsInvolvedNamespace: false
+  resourceQuota: true
+  externaldataProviderResponseCacheTTL: 3m
+  enableK8sNativeValidation: true
+  commonAnnotations: {}
+  extraVolumeMounts: []
+  extraVolumes: []
+  image:
+    repository: openpolicyagent/gatekeeper
+    crdRepository: openpolicyagent/gatekeeper-crds
+    release: v3.22.0-beta.0
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  preInstall:
+    crdRepository:
+      image:
+        repository: null
+        tag: v3.22.0-beta.0
+  postUpgrade:
+    labelNamespace:
+      serviceAccount:
+        name: gatekeeper-update-namespace-label-post-upgrade
+        create: true
+        enabled: false
+      image:
+        repository: openpolicyagent/gatekeeper-crds
+        tag: v3.22.0-beta.0
+        pullPolicy: IfNotPresent
+        pullSecrets: []
+      extraNamespaces: []
+      podSecurity: ["pod-security.kubernetes.io/audit=restricted",
+        "pod-security.kubernetes.io/audit-version=latest",
+        "pod-security.kubernetes.io/warn=restricted",
+        "pod-security.kubernetes.io/warn-version=latest",
+        "pod-security.kubernetes.io/enforce=restricted",
+        "pod-security.kubernetes.io/enforce-version=v1.24"]
+      extraAnnotations: {}
+      priorityClassName: ""
+      affinity: {}
+      tolerations: []
+      nodeSelector: {kubernetes.io/os: linux}
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 1000
+  postInstall:
+    labelNamespace:
+      serviceAccount:
+        name: gatekeeper-update-namespace-label
+        create: true
+        enabled: true
+      extraRules: []
+      image:
+        repository: openpolicyagent/gatekeeper-crds
+        tag: v3.22.0-beta.0
+        pullPolicy: IfNotPresent
+        pullSecrets: []
+      extraNamespaces: []
+      podSecurity: ["pod-security.kubernetes.io/audit=restricted",
+        "pod-security.kubernetes.io/audit-version=latest",
+        "pod-security.kubernetes.io/warn=restricted",
+        "pod-security.kubernetes.io/warn-version=latest",
+        "pod-security.kubernetes.io/enforce=restricted",
+        "pod-security.kubernetes.io/enforce-version=v1.24"]
+      extraAnnotations: {}
+      priorityClassName: ""
+      probeWebhook:
+        enabled: true
+        image:
+          repository: curlimages/curl
+          tag: 8.12.0
+          pullPolicy: IfNotPresent
+          pullSecrets: []
+        waitTimeout: 60
+        httpTimeout: 2
+        insecureHTTPS: false
+        priorityClassName: ""
+        affinity: {}
+        tolerations: []
+        nodeSelector: {kubernetes.io/os: linux}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 999
+          runAsNonRoot: true
+          runAsUser: 1000
+  preUninstall:
+    deleteWebhookConfigurations:
+      serviceAccount:
+        name: gatekeeper-delete-webhook-configs
+        create: true
+        extraRules: []
+        enabled: false
+      image:
+        repository: openpolicyagent/gatekeeper-crds
+        tag: v3.22.0-beta.0
+        pullPolicy: IfNotPresent
+        pullSecrets: []
+      priorityClassName: ""
+      affinity: {}
+      tolerations: []
+      nodeSelector: {kubernetes.io/os: linux}
+      resources: {}
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 1000
+  podAnnotations: {}
+  auditPodAnnotations: {}
+  podLabels: {}
+  podCountLimit: "100"
+  secretAnnotations: {}
+  enableRuntimeDefaultSeccompProfile: true
+  controllerManager:
+    serviceAccount:
+      name: gatekeeper-admin
+      automountServiceAccountToken: true
+    containerName: manager
+    exemptNamespaces: []
+    exemptNamespacePrefixes: []
+    hostNetwork: false
+    dnsPolicy: ClusterFirst
+    port: 8443
+    metricsPort: 8888
+    healthPort: 9090
+    readinessTimeout: 1
+    livenessTimeout: 1
+    priorityClassName: system-cluster-critical
+    disableCertRotation: false
+    tlsMinVersion: 1.3
+    clientCertName: ""
+    strategyType: RollingUpdate
+    strategyRollingUpdate: {}
+    podLabels: {}
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: gatekeeper.sh/operation
+                    operator: In
+                    values:
+                      - webhook
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+    topologySpreadConstraints: []
+    tolerations: []
+    nodeSelector: {kubernetes.io/os: linux}
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 512Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 999
+      runAsNonRoot: true
+      runAsUser: 1000
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999
+    extraRules: []
+    networkPolicy:
+      enabled: false
+      ingress: []
+    disableWebhookOperation: false
+    disableGenerateOperation: true
+  exportBackend: ""
+  audit:
+    exportConnection:
+      path: /tmp/violations/topics
+      maxAuditResults: 3
+    exportVolumeMount:
+      path: /tmp/violations
+    exportVolume:
+      name: tmp-violations
+      emptyDir: {}
+    exportSidecar:
+      name: reader
+      image: ghcr.io/open-policy-agent/fake-reader:latest
+      imagePullPolicy: Always
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+        readOnlyRootFilesystem: true
+        runAsGroup: 999
+        runAsNonRoot: true
+        runAsUser: 1000
+        seccompProfile:
+          type: RuntimeDefault
+      volumeMounts:
+        - mountPath: /tmp/violations
+          name: tmp-violations
+    serviceAccount:
+      name: gatekeeper-admin
+      automountServiceAccountToken: true
+    containerName: manager
+    hostNetwork: false
+    dnsPolicy: ClusterFirst
+    metricsPort: 8888
+    healthPort: 9090
+    readinessTimeout: 1
+    livenessTimeout: 1
+    priorityClassName: system-cluster-critical
+    disableCertRotation: false
+    podLabels: {}
+    affinity: {}
+    tolerations: []
+    nodeSelector: {kubernetes.io/os: linux}
+    resources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 512Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 999
+      runAsNonRoot: true
+      runAsUser: 1000
+    podSecurityContext:
+      fsGroup: 999
+      supplementalGroups:
+        - 999
+    writeToRAMDisk: false
+    extraRules: []
+    disableGenerateOperation: false
+    disableAuditOperation: false
+    disableStatusOperation: false
+  crds:
+    affinity: {}
+    tolerations: []
+    nodeSelector: {kubernetes.io/os: linux}
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
+      runAsGroup: 65532
+      runAsNonRoot: true
+      runAsUser: 65532
+  pdb:
+    controllerManager:
+      minAvailable: 1
+  service: {}
+  disabledBuiltins: ["{http.send}"]
+  upgradeCRDs:
+    serviceAccount:
+      create: true
+      name: gatekeeper-admin-upgrade-crds
+      enabled: true
+      extraRules: []
+      priorityClassName: ""
+  rbac:
+    create: true
+  externalCertInjection:
+    enabled: false
+    secretName: gatekeeper-webhook-server-cert
+  serviceAccount:
+    gatekeeperAdmin:
+      create: true

--- a/charts/kube-gatekeeper/values.yaml
+++ b/charts/kube-gatekeeper/values.yaml
@@ -79,11 +79,11 @@ spec:
         pullSecrets: []
       extraNamespaces: []
       podSecurity: ["pod-security.kubernetes.io/audit=restricted",
-        "pod-security.kubernetes.io/audit-version=latest",
-        "pod-security.kubernetes.io/warn=restricted",
-        "pod-security.kubernetes.io/warn-version=latest",
-        "pod-security.kubernetes.io/enforce=restricted",
-        "pod-security.kubernetes.io/enforce-version=v1.24"]
+                    "pod-security.kubernetes.io/audit-version=latest",
+                    "pod-security.kubernetes.io/warn=restricted",
+                    "pod-security.kubernetes.io/warn-version=latest",
+                    "pod-security.kubernetes.io/enforce=restricted",
+                    "pod-security.kubernetes.io/enforce-version=v1.24"]
       extraAnnotations: {}
       priorityClassName: ""
       affinity: {}
@@ -113,11 +113,11 @@ spec:
         pullSecrets: []
       extraNamespaces: []
       podSecurity: ["pod-security.kubernetes.io/audit=restricted",
-        "pod-security.kubernetes.io/audit-version=latest",
-        "pod-security.kubernetes.io/warn=restricted",
-        "pod-security.kubernetes.io/warn-version=latest",
-        "pod-security.kubernetes.io/enforce=restricted",
-        "pod-security.kubernetes.io/enforce-version=v1.24"]
+                    "pod-security.kubernetes.io/audit-version=latest",
+                    "pod-security.kubernetes.io/warn=restricted",
+                    "pod-security.kubernetes.io/warn-version=latest",
+                    "pod-security.kubernetes.io/enforce=restricted",
+                    "pod-security.kubernetes.io/enforce-version=v1.24"]
       extraAnnotations: {}
       priorityClassName: ""
       probeWebhook:


### PR DESCRIPTION
## Description

Adds a new wrapper Helm chart `kube-gatekeeper` that wraps the official [Gatekeeper](https://github.com/open-policy-agent/gatekeeper) chart from the Open Policy Agent project. Gatekeeper is a policy controller for Kubernetes that enforces custom resource-based policies (Constraint Templates and Constraints) and validates admission requests.

**Changes:**
- New chart `charts/kube-gatekeeper` with dependency on upstream `gatekeeper` (open-policy-agent/gatekeeper) v3.22.0-beta.0
- Upstream values exposed under `spec` following the kube-* wrapper pattern
- Chart.yaml, values.yaml, values.schema.json, README.md, .helmignore, Makefile, and release.json

No additional dependencies required; the chart pulls the upstream dependency from https://open-policy-agent.github.io/gatekeeper/charts.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chart Version Update

## How Has This Been Tested?

- Chart structure and `helm dependency update` / `helm template` validated locally
- README and values follow existing wrapper chart patterns (e.g. kube-oauth2-proxy)

## Checklist:

- [x] My code follows the contribution guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation (README.md).
- [x] Chart.yaml includes version and appVersion (3.22.0-beta.0).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes (if applicable).
- [ ] I have tested my changes on a live Kubernetes cluster (optional for new chart addition).

## Additional Information

Wrapper chart mirrors upstream Gatekeeper defaults; all upstream options are configurable under `spec` in values.yaml.

---
By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.
