### PR TITLE
feat(charts): upgrade kube-karpenter chart to v1.10.0

### DIFF
--- a/charts/kube-karpenter/Chart.yaml
+++ b/charts/kube-karpenter/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kube-karpenter
 description: A Helm chart for Karpenter, an open-source node provisioning project built for Kubernetes.
 type: application
-version: 0.35.1
-appVersion: 0.35.1
+version: 1.10.0
+appVersion: 1.10.0
 kubeVersion: '>=1.20.0-0'
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/
@@ -21,4 +21,4 @@ dependencies:
   - name: karpenter
     alias: spec
     repository: oci://public.ecr.aws/karpenter
-    version: 0.35.1
+    version: 1.10.0

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -55,7 +55,7 @@ spec:
     # -- Strategy for updating the pod.
     strategy:
         rollingUpdate:
-          maxUnavailable: 1
+            maxUnavailable: 1
     # -- Additional labels for the pod.
     podLabels: {}
     # -- Additional annotations for the pod.
@@ -67,7 +67,7 @@ spec:
     podSecurityContext:
         fsGroup: 65532
         seccompProfile:
-          type: RuntimeDefault
+            type: RuntimeDefault
     # -- PriorityClass name for the pod.
     priorityClassName: system-cluster-critical
     # -- Override the default termination grace period for the pod.
@@ -95,14 +95,14 @@ spec:
     # -- Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
     affinity:
         nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: karpenter.sh/nodepool
-                    operator: DoesNotExist
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: karpenter.sh/nodepool
+                      operator: DoesNotExist
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: "kubernetes.io/hostname"
+            requiredDuringSchedulingIgnoredDuringExecution:
+              - topologyKey: "kubernetes.io/hostname"
     # -- Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels.
     topologySpreadConstraints:
         - maxSkew: 1
@@ -126,24 +126,24 @@ spec:
         # -- Distinguishing container name (containerName: karpenter-controller).
         containerName: controller
         image:
-          # -- Repository path to the controller image.
-          repository: public.ecr.aws/karpenter/controller
-          # -- Tag of the controller image.
-          tag: 1.10.0
-          # -- SHA256 digest of the controller image.
-          digest: sha256:0c215133a37e0d8bc2515b75120d2fefa14be3f939aebc14020813cdc3c001a3
+            # -- Repository path to the controller image.
+            repository: public.ecr.aws/karpenter/controller
+            # -- Tag of the controller image.
+            tag: 1.10.0
+            # -- SHA256 digest of the controller image.
+            digest: sha256:0c215133a37e0d8bc2515b75120d2fefa14be3f939aebc14020813cdc3c001a3
         # -- Additional environment variables for the controller pod.
         env: []
         # - name: AWS_REGION
         #   value: eu-west-1
         envFrom: []
         securityContext:
-          # -- AppArmor profile for the controller container.
-          appArmorProfile: {}
-          # -- SELinux options for the controller container.
-          seLinuxOptions: {}
-          # -- Seccomp profile for the controller container.
-          seccompProfile: {}
+            # -- AppArmor profile for the controller container.
+            appArmorProfile: {}
+            # -- SELinux options for the controller container.
+            seLinuxOptions: {}
+            # -- Seccomp profile for the controller container.
+            seccompProfile: {}
         # -- Resources for the controller container.
         resources: {}
         # We usually recommend not to specify default resources and to leave this as a conscious
@@ -166,11 +166,11 @@ spec:
         # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
         sidecarVolumeMounts: []
         metrics:
-          # -- The container port to use for metrics.
-          port: 8080
+            # -- The container port to use for metrics.
+            port: 8080
         healthProbe:
-          # -- The container port to use for http health probe.
-          port: 8081
+            # -- The container port to use for http health probe.
+            port: 8081
     # -- Global log level, defaults to 'info'
     logLevel: info
     # -- Log outputPaths - defaults to stdout only
@@ -222,18 +222,18 @@ spec:
         # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
         # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features.
         featureGates:
-          # -- nodeRepair is ALPHA and is disabled by default.
-          # Setting this to true will enable node repair.
-          nodeRepair: false
-          # -- nodeOverlay is ALPHA and is disabled by default.
-          # Setting this will allow the use of node overlay to impact scheduling decisions
-          nodeOverlay: false
-          # -- reservedCapacity is BETA and is enabled by default.
-          # Setting this will enable native on-demand capacity reservation support.
-          reservedCapacity: true
-          # -- spotToSpotConsolidation is ALPHA and is disabled by default.
-          # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
-          spotToSpotConsolidation: false
-          # -- staticCapacity is ALPHA and is disabled by default.
-          # Setting this to true will enable static capacity provisioning.
-          staticCapacity: false
+            # -- nodeRepair is ALPHA and is disabled by default.
+            # Setting this to true will enable node repair.
+            nodeRepair: false
+            # -- nodeOverlay is ALPHA and is disabled by default.
+            # Setting this will allow the use of node overlay to impact scheduling decisions
+            nodeOverlay: false
+            # -- reservedCapacity is BETA and is enabled by default.
+            # Setting this will enable native on-demand capacity reservation support.
+            reservedCapacity: true
+            # -- spotToSpotConsolidation is ALPHA and is disabled by default.
+            # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
+            spotToSpotConsolidation: false
+            # -- staticCapacity is ALPHA and is disabled by default.
+            # Setting this to true will enable static capacity provisioning.
+            staticCapacity: false

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -96,13 +96,13 @@ spec:
     affinity:
         nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              nodeSelectorTerms:
-                - matchExpressions:
-                    - key: karpenter.sh/nodepool
-                      operator: DoesNotExist
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: karpenter.sh/nodepool
+                        operator: DoesNotExist
         podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
-              - topologyKey: "kubernetes.io/hostname"
+                - topologyKey: "kubernetes.io/hostname"
     # -- Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels.
     topologySpreadConstraints:
         - maxSkew: 1

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -133,9 +133,13 @@ spec:
             # -- SHA256 digest of the controller image.
             digest: sha256:0c215133a37e0d8bc2515b75120d2fefa14be3f939aebc14020813cdc3c001a3
         # -- Additional environment variables for the controller pod.
-        env: []
-        # - name: AWS_REGION
-        #   value: eu-west-1
+        # Default entries avoid IMDS from the pod (panic: unable to determine region from IMDS / ec2imds getToken 400).
+        # Override AWS_REGION to the same region as your EKS control plane.
+        env:
+            - name: AWS_EC2_METADATA_DISABLED
+              value: "true"
+            - name: AWS_REGION
+              value: "eu-west-1"
         envFrom: []
         securityContext:
             # -- AppArmor profile for the controller container.

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -98,8 +98,8 @@ spec:
             requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
                     - matchExpressions:
-                        - key: karpenter.sh/nodepool
-                          operator: DoesNotExist
+                          - key: karpenter.sh/nodepool
+                            operator: DoesNotExist
         podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
                 - topologyKey: "kubernetes.io/hostname"

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -107,7 +107,7 @@ spec:
     topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone
-          whenUnsatisfiable: DoNotSchedule
+          whenUnsatisfiable: ScheduleAnyway
     # -- Tolerations to allow the pod to be scheduled to nodes with taints.
     tolerations:
         - key: CriticalAddonsOnly

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -97,9 +97,9 @@ spec:
         nodeAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
                 nodeSelectorTerms:
-                  - matchExpressions:
-                      - key: karpenter.sh/nodepool
-                        operator: DoesNotExist
+                    - matchExpressions:
+                        - key: karpenter.sh/nodepool
+                          operator: DoesNotExist
         podAntiAffinity:
             requiredDuringSchedulingIgnoredDuringExecution:
                 - topologyKey: "kubernetes.io/hostname"

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -1,216 +1,239 @@
 ## @param spec The spec of the Karpenter deployment
 ## @skip spec
 spec:
-  # -- Overrides the chart's name.
-  nameOverride: ""
-  # -- Overrides the chart's computed fullname.
-  fullnameOverride: ""
-  # -- Additional labels to add into metadata.
-  additionalLabels: {}
-  # app: karpenter
-
-  # -- Additional annotations to add into metadata.
-  additionalAnnotations: {}
-  # -- Image pull policy for Docker images.
-  imagePullPolicy: IfNotPresent
-  # -- Image pull secrets for Docker images.
-  imagePullSecrets: []
-  serviceAccount:
-    # -- Specifies if a ServiceAccount should be created.
-    create: true
-    # -- The name of the ServiceAccount to use.
-    # If not set and create is true, a name is generated using the fullname template.
-    name: ""
-    # -- Additional annotations for the ServiceAccount.
-    annotations: {}
-  # -- Specifies additional rules for the core ClusterRole.
-  additionalClusterRoleRules: []
-  serviceMonitor:
-    # -- Specifies whether a ServiceMonitor should be created.
-    enabled: false
-    # -- Additional labels for the ServiceMonitor.
+    # -- Overrides the chart's name.
+    nameOverride: ""
+    # -- Overrides the chart's computed fullname.
+    fullnameOverride: ""
+    # -- Additional labels to add into metadata.
     additionalLabels: {}
-    # -- Endpoint configuration for the ServiceMonitor.
-    endpointConfig: {}
-  # -- Number of replicas.
-  replicas: 2
-  # -- The number of old ReplicaSets to retain to allow rollback.
-  revisionHistoryLimit: 10
-  # -- Strategy for updating the pod.
-  strategy:
-    rollingUpdate:
-      maxUnavailable: 1
-  # -- Additional labels for the pod.
-  podLabels: {}
-  # -- Additional annotations for the pod.
-  podAnnotations: {}
-  podDisruptionBudget:
-    name: karpenter
-    maxUnavailable: 1
-  # -- SecurityContext for the pod.
-  podSecurityContext:
-    fsGroup: 65536
-  # -- PriorityClass name for the pod.
-  priorityClassName: system-cluster-critical
-  # -- Override the default termination grace period for the pod.
-  terminationGracePeriodSeconds:
-  # -- Bind the pod to the host network.
-  # This is required when using a custom CNI.
-  hostNetwork: false
-  # -- Configure the DNS Policy for the pod
-  dnsPolicy: ClusterFirst
-  # -- Configure DNS Config for the pod
-  dnsConfig: {}
-  #  options:
-  #    - name: ndots
-  #      value: "1"
-  # -- Node selectors to schedule the pod to nodes with labels.
-  nodeSelector:
-    kubernetes.io/os: linux
-  # -- Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        nodeSelectorTerms:
-          - matchExpressions:
-              - key: karpenter.sh/nodepool
-                operator: DoesNotExist
-    podAntiAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
-        - topologyKey: "kubernetes.io/hostname"
-  # -- Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels.
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: ScheduleAnyway
-  # -- Tolerations to allow the pod to be scheduled to nodes with taints.
-  tolerations:
-    - key: CriticalAddonsOnly
-      operator: Exists
-  # -- Additional volumes for the pod.
-  extraVolumes: []
-  # - name: aws-iam-token
-  #   projected:
-  #     defaultMode: 420
-  #     sources:
-  #     - serviceAccountToken:
-  #         audience: sts.amazonaws.com
-  #         expirationSeconds: 86400
-  #         path: token
-  controller:
-    image:
-      # -- Repository path to the controller image.
-      repository: public.ecr.aws/karpenter/controller
-      # -- Tag of the controller image.
-      tag: 0.35.1
-      # -- SHA256 digest of the controller image.
-      digest: sha256:2872aea8b875ca1f543d0a4f369364c5c4baf6a463c6b2253a75406a7ab9025b
-    # -- Additional environment variables for the controller pod.
-    env: []
-    # - name: AWS_REGION
-    #   value: eu-west-1
-    envFrom: []
-    # -- Resources for the controller pod.
-    resources:
-      requests:
-        cpu: 2
-        memory: 2Gi
-      limits:
-        cpu: 2
-        memory: 2Gi
-    # We usually recommend not to specify default resources and to leave this as a conscious
-    # choice for the user. This also increases chances charts run on environments with little
-    # resources, such as Minikube. If you do want to specify resources, uncomment the following
-    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-    #  requests:
-    #    cpu: 1
-    #    memory: 1Gi
-    #  limits:
-    #    cpu: 1
-    #    memory: 1Gi
+    # app: karpenter
 
-    # -- Additional volumeMounts for the controller pod.
-    extraVolumeMounts: []
+    # -- Additional annotations to add into metadata.
+    additionalAnnotations: {}
+    # -- Image pull policy for Docker images.
+    imagePullPolicy: IfNotPresent
+    # -- Image pull secrets for Docker images.
+    imagePullSecrets: []
+    service:
+      # -- Additional annotations for the Service.
+      annotations: {}
+    serviceAccount:
+      # -- Specifies if a ServiceAccount should be created.
+      create: true
+      # -- The name of the ServiceAccount to use.
+      # If not set and create is true, a name is generated using the fullname template.
+      name: ""
+      # -- Additional annotations for the ServiceAccount.
+      annotations: {}
+    # -- Specifies additional rules for the core ClusterRole.
+    additionalClusterRoleRules: []
+    serviceMonitor:
+      # -- Specifies whether a ServiceMonitor should be created.
+      enabled: false
+      # -- Additional labels for the ServiceMonitor.
+      additionalLabels: {}
+      # -- Relabelings for the `http-metrics` endpoint on the ServiceMonitor.
+      # For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+      relabelings: []
+      # -- Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor.
+      # For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+      metricRelabelings: []
+      # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
+      # Not to be used to add additional endpoints.
+      # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
+      endpointConfig: {}
+      # -- Specifies the sampleLimit for prometheus scrapes.
+      # Per-scrape limit on the number of scraped samples that will be accepted.
+      # If more than this number of samples are present after metric relabeling
+      # the entire scrape will be treated as failed. 0 means no limit.
+      sampleLimit: null
+    # -- Number of replicas.
+    replicas: 2
+    # -- The number of old ReplicaSets to retain to allow rollback.
+    revisionHistoryLimit: 10
+    # -- Strategy for updating the pod.
+    strategy:
+      rollingUpdate:
+        maxUnavailable: 1
+    # -- Additional labels for the pod.
+    podLabels: {}
+    # -- Additional annotations for the pod.
+    podAnnotations: {}
+    podDisruptionBudget:
+      name: karpenter
+      maxUnavailable: 1
+    # -- SecurityContext for the pod.
+    podSecurityContext:
+      fsGroup: 65532
+      seccompProfile:
+        type: RuntimeDefault
+    # -- PriorityClass name for the pod.
+    priorityClassName: system-cluster-critical
+    # -- Override the default termination grace period for the pod.
+    terminationGracePeriodSeconds:
+    # -- Bind the pod to the host network.
+    # This is required when using a custom CNI.
+    hostNetwork: false
+    # -- Specify which Kubernetes scheduler should dispatch the pod.
+    schedulerName: default-scheduler
+    # -- Configure the DNS Policy for the pod
+    dnsPolicy: ClusterFirst
+    # -- Configure DNS Config for the pod
+    dnsConfig: {}
+    #  options:
+    #    - name: ndots
+    #      value: "1"
+    # -- add additional initContainers to run before karpenter container starts
+    initContainers: {}
+    #  - name: list-ec2-instances
+    #    image: amazon/aws-cli:latest
+    #    command: [ 'aws', 'ec2', 'describe-instance-types']
+    # -- Node selectors to schedule the pod to nodes with labels.
+    nodeSelector:
+      kubernetes.io/os: linux
+    # -- Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: karpenter.sh/nodepool
+                  operator: DoesNotExist
+      podAntiAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+    # -- Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels.
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: DoNotSchedule
+    # -- Tolerations to allow the pod to be scheduled to nodes with taints.
+    tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+    # -- Additional volumes for the pod.
+    extraVolumes: []
     # - name: aws-iam-token
-    #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
-    #   readOnly: true
-    # -- Additional sidecarContainer config
-    sidecarContainer: []
-    # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
-    sidecarVolumeMounts: []
-    metrics:
-      # -- The container port to use for metrics.
-      port: 8000
-    healthProbe:
-      # -- The container port to use for http health probe.
-      port: 8081
-  webhook:
-    # -- Whether to enable the webhooks and webhook permissions.
-    enabled: false
-    # -- The container port to use for the webhook.
-    port: 8443
-    metrics:
-      # -- The container port to use for webhook metrics.
-      port: 8001
-  # -- Global log level, defaults to 'info'
-  logLevel: info
-  # -- Log configuration (Deprecated: Logging configuration will be dropped by v1, use logLevel instead)
-  logConfig:
-    # -- Whether to enable provisioning and mounting the log ConfigMap
-    enabled: false
+    #   projected:
+    #     defaultMode: 420
+    #     sources:
+    #     - serviceAccountToken:
+    #         audience: sts.amazonaws.com
+    #         expirationSeconds: 86400
+    #         path: token
+    controller:
+      # -- Distinguishing container name (containerName: karpenter-controller).
+      containerName: controller
+      image:
+        # -- Repository path to the controller image.
+        repository: public.ecr.aws/karpenter/controller
+        # -- Tag of the controller image.
+        tag: 1.10.0
+        # -- SHA256 digest of the controller image.
+        digest: sha256:0c215133a37e0d8bc2515b75120d2fefa14be3f939aebc14020813cdc3c001a3
+      # -- Additional environment variables for the controller pod.
+      env: []
+      # - name: AWS_REGION
+      #   value: eu-west-1
+      envFrom: []
+      securityContext:
+        # -- AppArmor profile for the controller container.
+        appArmorProfile: {}
+        # -- SELinux options for the controller container.
+        seLinuxOptions: {}
+        # -- Seccomp profile for the controller container.
+        seccompProfile: {}
+      # -- Resources for the controller container.
+      resources: {}
+      # We usually recommend not to specify default resources and to leave this as a conscious
+      # choice for the user. This also increases chances charts run on environments with little
+      # resources, such as Minikube. If you do want to specify resources, uncomment the following
+      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+      #  requests:
+      #    cpu: 1
+      #    memory: 1Gi
+      #  limits:
+      #    cpu: 1
+      #    memory: 1Gi
+      # -- Additional volumeMounts for the controller container.
+      extraVolumeMounts: []
+      # - name: aws-iam-token
+      #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+      #   readOnly: true
+      # -- Additional sidecarContainer config
+      sidecarContainer: []
+      # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
+      sidecarVolumeMounts: []
+      metrics:
+        # -- The container port to use for metrics.
+        port: 8080
+      healthProbe:
+        # -- The container port to use for http health probe.
+        port: 8081
+    # -- Global log level, defaults to 'info'
+    logLevel: info
     # -- Log outputPaths - defaults to stdout only
-    outputPaths:
+    logOutputPaths:
       - stdout
     # -- Log errorOutputPaths - defaults to stderr only
-    errorOutputPaths:
+    logErrorOutputPaths:
       - stderr
-    # -- Log encoding - defaults to json - must be one of 'json', 'console'
-    logEncoding: json
-    # -- Component-based log configuration
-    logLevel:
-      # -- Global log level, defaults to 'info'
-      global: info
-      # -- Controller log level, defaults to 'info'
-      controller: info
-      # -- Error log level, defaults to 'error'
-      webhook: error
-  # -- Global Settings to configure Karpenter
-  settings:
-    # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one
-    # time which usually results in fewer but larger nodes.
-    batchMaxDuration: 10s
-    # -- The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive
-    # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
-    # will be batched separately.
-    batchIdleDuration: 1s
-    # -- Role to assume for calling AWS services.
-    assumeRoleARN: ""
-    # -- Duration of assumed credentials in minutes. Default value is 15 minutes. Not used unless assumeRoleARN set.
-    assumeRoleDuration: 15m
-    # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
-    clusterCABundle: ""
-    # -- Cluster name.
-    clusterName: ""
-    # -- Cluster endpoint. If not set, will be discovered during startup (EKS only)
-    clusterEndpoint: ""
-    # -- If true then assume we can't reach AWS services which don't have a VPC endpoint
-    # This also has the effect of disabling look-ups to the AWS pricing endpoint
-    isolatedVPC: false
-    # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types
-    vmMemoryOverheadPercent: 0.075
-    # -- interruptionQueue is disabled if not specified. Enabling interruption handling may
-    # require additional permissions on the controller service account. Additional permissions are outlined in the docs.
-    interruptionQueue: ""
-    # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved
-    # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html
-    reservedENIs: "0"
-    # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
-    # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features
-    featureGates:
-      # -- drift is in BETA and is enabled by default.
-      # Setting drift to false disables the drift disruption method to watch for drift between currently deployed nodes
-      # and the desired state of nodes set in nodepools and nodeclasses
-      drift: true
-      # -- spotToSpotConsolidation is disabled by default.
-      # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
-      spotToSpotConsolidation: false
+    # -- Global Settings to configure Karpenter
+    settings:
+      # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one
+      # time which usually results in fewer but larger nodes.
+      batchMaxDuration: 10s
+      # -- The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive
+      # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
+      # will be batched separately.
+      batchIdleDuration: 1s
+      # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
+      # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
+      preferencePolicy: Respect
+      # -- How the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met).
+      minValuesPolicy: Strict
+      # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
+      clusterCABundle: ""
+      # -- Cluster name.
+      clusterName: "karpenter"
+      # -- Cluster endpoint. If not set, will be discovered during startup (EKS only).
+      clusterEndpoint: ""
+      # -- If true then assume we can't reach AWS services which don't have a VPC endpoint.
+      # This also has the effect of disabling look-ups to the AWS pricing endpoint.
+      isolatedVPC: false
+      # -- Marking this true means that your cluster is running with an EKS control plane and Karpenter should attempt to discover cluster details from the DescribeCluster API.
+      eksControlPlane: false
+      # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.
+      vmMemoryOverheadPercent: 0.075
+      # -- Interruption queue is the name of the SQS queue used for processing interruption events from EC2.
+      # Interruption handling is disabled if not specified. Enabling interruption handling may
+      # require additional permissions on the controller service account. Additional permissions are outlined in the docs.
+      interruptionQueue: ""
+      # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved.
+      # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.
+      reservedENIs: "0"
+      # -- Ignore pods' DRA requests during scheduling simulations.
+      ignoreDRARequests: true
+      # -- Disable cluster state metrics and events.
+      disableClusterStateObservability: false
+      # -- Disable dry run validation for EC2NodeClasses.
+      disableDryRun: false
+      # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
+      # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features.
+      featureGates:
+        # -- nodeRepair is ALPHA and is disabled by default.
+        # Setting this to true will enable node repair.
+        nodeRepair: false
+        # -- nodeOverlay is ALPHA and is disabled by default.
+        # Setting this will allow the use of node overlay to impact scheduling decisions
+        nodeOverlay: false
+        # -- reservedCapacity is BETA and is enabled by default.
+        # Setting this will enable native on-demand capacity reservation support.
+        reservedCapacity: true
+        # -- spotToSpotConsolidation is ALPHA and is disabled by default.
+        # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
+        spotToSpotConsolidation: false
+        # -- staticCapacity is ALPHA and is disabled by default.
+        # Setting this to true will enable static capacity provisioning.
+        staticCapacity: false

--- a/charts/kube-karpenter/values.yaml
+++ b/charts/kube-karpenter/values.yaml
@@ -16,58 +16,58 @@ spec:
     # -- Image pull secrets for Docker images.
     imagePullSecrets: []
     service:
-      # -- Additional annotations for the Service.
-      annotations: {}
+        # -- Additional annotations for the Service.
+        annotations: {}
     serviceAccount:
-      # -- Specifies if a ServiceAccount should be created.
-      create: true
-      # -- The name of the ServiceAccount to use.
-      # If not set and create is true, a name is generated using the fullname template.
-      name: ""
-      # -- Additional annotations for the ServiceAccount.
-      annotations: {}
+        # -- Specifies if a ServiceAccount should be created.
+        create: true
+        # -- The name of the ServiceAccount to use.
+        # If not set and create is true, a name is generated using the fullname template.
+        name: ""
+        # -- Additional annotations for the ServiceAccount.
+        annotations: {}
     # -- Specifies additional rules for the core ClusterRole.
     additionalClusterRoleRules: []
     serviceMonitor:
-      # -- Specifies whether a ServiceMonitor should be created.
-      enabled: false
-      # -- Additional labels for the ServiceMonitor.
-      additionalLabels: {}
-      # -- Relabelings for the `http-metrics` endpoint on the ServiceMonitor.
-      # For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
-      relabelings: []
-      # -- Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor.
-      # For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
-      metricRelabelings: []
-      # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
-      # Not to be used to add additional endpoints.
-      # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
-      endpointConfig: {}
-      # -- Specifies the sampleLimit for prometheus scrapes.
-      # Per-scrape limit on the number of scraped samples that will be accepted.
-      # If more than this number of samples are present after metric relabeling
-      # the entire scrape will be treated as failed. 0 means no limit.
-      sampleLimit: null
+        # -- Specifies whether a ServiceMonitor should be created.
+        enabled: false
+        # -- Additional labels for the ServiceMonitor.
+        additionalLabels: {}
+        # -- Relabelings for the `http-metrics` endpoint on the ServiceMonitor.
+        # For more details on relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+        relabelings: []
+        # -- Metric relabelings for the `http-metrics` endpoint on the ServiceMonitor.
+        # For more details on metric relabelings, see: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#metric_relabel_configs
+        metricRelabelings: []
+        # -- Configuration on `http-metrics` endpoint for the ServiceMonitor.
+        # Not to be used to add additional endpoints.
+        # See the Prometheus operator documentation for configurable fields https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api-reference/api.md#endpoint
+        endpointConfig: {}
+        # -- Specifies the sampleLimit for prometheus scrapes.
+        # Per-scrape limit on the number of scraped samples that will be accepted.
+        # If more than this number of samples are present after metric relabeling
+        # the entire scrape will be treated as failed. 0 means no limit.
+        sampleLimit: null
     # -- Number of replicas.
     replicas: 2
     # -- The number of old ReplicaSets to retain to allow rollback.
     revisionHistoryLimit: 10
     # -- Strategy for updating the pod.
     strategy:
-      rollingUpdate:
-        maxUnavailable: 1
+        rollingUpdate:
+          maxUnavailable: 1
     # -- Additional labels for the pod.
     podLabels: {}
     # -- Additional annotations for the pod.
     podAnnotations: {}
     podDisruptionBudget:
-      name: karpenter
-      maxUnavailable: 1
+        name: karpenter
+        maxUnavailable: 1
     # -- SecurityContext for the pod.
     podSecurityContext:
-      fsGroup: 65532
-      seccompProfile:
-        type: RuntimeDefault
+        fsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
     # -- PriorityClass name for the pod.
     priorityClassName: system-cluster-critical
     # -- Override the default termination grace period for the pod.
@@ -91,27 +91,27 @@ spec:
     #    command: [ 'aws', 'ec2', 'describe-instance-types']
     # -- Node selectors to schedule the pod to nodes with labels.
     nodeSelector:
-      kubernetes.io/os: linux
+        kubernetes.io/os: linux
     # -- Affinity rules for scheduling the pod. If an explicit label selector is not provided for pod affinity or pod anti-affinity one will be created from the pod selector labels.
     affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: karpenter.sh/nodepool
-                  operator: DoesNotExist
-      podAntiAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          - topologyKey: "kubernetes.io/hostname"
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: karpenter.sh/nodepool
+                    operator: DoesNotExist
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - topologyKey: "kubernetes.io/hostname"
     # -- Topology spread constraints to increase the controller resilience by distributing pods across the cluster zones. If an explicit label selector is not provided one will be created from the pod selector labels.
     topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: DoNotSchedule
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
     # -- Tolerations to allow the pod to be scheduled to nodes with taints.
     tolerations:
-      - key: CriticalAddonsOnly
-        operator: Exists
+        - key: CriticalAddonsOnly
+          operator: Exists
     # -- Additional volumes for the pod.
     extraVolumes: []
     # - name: aws-iam-token
@@ -123,117 +123,117 @@ spec:
     #         expirationSeconds: 86400
     #         path: token
     controller:
-      # -- Distinguishing container name (containerName: karpenter-controller).
-      containerName: controller
-      image:
-        # -- Repository path to the controller image.
-        repository: public.ecr.aws/karpenter/controller
-        # -- Tag of the controller image.
-        tag: 1.10.0
-        # -- SHA256 digest of the controller image.
-        digest: sha256:0c215133a37e0d8bc2515b75120d2fefa14be3f939aebc14020813cdc3c001a3
-      # -- Additional environment variables for the controller pod.
-      env: []
-      # - name: AWS_REGION
-      #   value: eu-west-1
-      envFrom: []
-      securityContext:
-        # -- AppArmor profile for the controller container.
-        appArmorProfile: {}
-        # -- SELinux options for the controller container.
-        seLinuxOptions: {}
-        # -- Seccomp profile for the controller container.
-        seccompProfile: {}
-      # -- Resources for the controller container.
-      resources: {}
-      # We usually recommend not to specify default resources and to leave this as a conscious
-      # choice for the user. This also increases chances charts run on environments with little
-      # resources, such as Minikube. If you do want to specify resources, uncomment the following
-      # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-      #  requests:
-      #    cpu: 1
-      #    memory: 1Gi
-      #  limits:
-      #    cpu: 1
-      #    memory: 1Gi
-      # -- Additional volumeMounts for the controller container.
-      extraVolumeMounts: []
-      # - name: aws-iam-token
-      #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
-      #   readOnly: true
-      # -- Additional sidecarContainer config
-      sidecarContainer: []
-      # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
-      sidecarVolumeMounts: []
-      metrics:
-        # -- The container port to use for metrics.
-        port: 8080
-      healthProbe:
-        # -- The container port to use for http health probe.
-        port: 8081
+        # -- Distinguishing container name (containerName: karpenter-controller).
+        containerName: controller
+        image:
+          # -- Repository path to the controller image.
+          repository: public.ecr.aws/karpenter/controller
+          # -- Tag of the controller image.
+          tag: 1.10.0
+          # -- SHA256 digest of the controller image.
+          digest: sha256:0c215133a37e0d8bc2515b75120d2fefa14be3f939aebc14020813cdc3c001a3
+        # -- Additional environment variables for the controller pod.
+        env: []
+        # - name: AWS_REGION
+        #   value: eu-west-1
+        envFrom: []
+        securityContext:
+          # -- AppArmor profile for the controller container.
+          appArmorProfile: {}
+          # -- SELinux options for the controller container.
+          seLinuxOptions: {}
+          # -- Seccomp profile for the controller container.
+          seccompProfile: {}
+        # -- Resources for the controller container.
+        resources: {}
+        # We usually recommend not to specify default resources and to leave this as a conscious
+        # choice for the user. This also increases chances charts run on environments with little
+        # resources, such as Minikube. If you do want to specify resources, uncomment the following
+        # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+        #  requests:
+        #    cpu: 1
+        #    memory: 1Gi
+        #  limits:
+        #    cpu: 1
+        #    memory: 1Gi
+        # -- Additional volumeMounts for the controller container.
+        extraVolumeMounts: []
+        # - name: aws-iam-token
+        #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+        #   readOnly: true
+        # -- Additional sidecarContainer config
+        sidecarContainer: []
+        # -- Additional volumeMounts for the sidecar - this will be added to the volume mounts on top of extraVolumeMounts
+        sidecarVolumeMounts: []
+        metrics:
+          # -- The container port to use for metrics.
+          port: 8080
+        healthProbe:
+          # -- The container port to use for http health probe.
+          port: 8081
     # -- Global log level, defaults to 'info'
     logLevel: info
     # -- Log outputPaths - defaults to stdout only
     logOutputPaths:
-      - stdout
+        - stdout
     # -- Log errorOutputPaths - defaults to stderr only
     logErrorOutputPaths:
-      - stderr
+        - stderr
     # -- Global Settings to configure Karpenter
     settings:
-      # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one
-      # time which usually results in fewer but larger nodes.
-      batchMaxDuration: 10s
-      # -- The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive
-      # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
-      # will be batched separately.
-      batchIdleDuration: 1s
-      # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
-      # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
-      preferencePolicy: Respect
-      # -- How the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met).
-      minValuesPolicy: Strict
-      # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
-      clusterCABundle: ""
-      # -- Cluster name.
-      clusterName: "karpenter"
-      # -- Cluster endpoint. If not set, will be discovered during startup (EKS only).
-      clusterEndpoint: ""
-      # -- If true then assume we can't reach AWS services which don't have a VPC endpoint.
-      # This also has the effect of disabling look-ups to the AWS pricing endpoint.
-      isolatedVPC: false
-      # -- Marking this true means that your cluster is running with an EKS control plane and Karpenter should attempt to discover cluster details from the DescribeCluster API.
-      eksControlPlane: false
-      # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.
-      vmMemoryOverheadPercent: 0.075
-      # -- Interruption queue is the name of the SQS queue used for processing interruption events from EC2.
-      # Interruption handling is disabled if not specified. Enabling interruption handling may
-      # require additional permissions on the controller service account. Additional permissions are outlined in the docs.
-      interruptionQueue: ""
-      # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved.
-      # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.
-      reservedENIs: "0"
-      # -- Ignore pods' DRA requests during scheduling simulations.
-      ignoreDRARequests: true
-      # -- Disable cluster state metrics and events.
-      disableClusterStateObservability: false
-      # -- Disable dry run validation for EC2NodeClasses.
-      disableDryRun: false
-      # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
-      # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features.
-      featureGates:
-        # -- nodeRepair is ALPHA and is disabled by default.
-        # Setting this to true will enable node repair.
-        nodeRepair: false
-        # -- nodeOverlay is ALPHA and is disabled by default.
-        # Setting this will allow the use of node overlay to impact scheduling decisions
-        nodeOverlay: false
-        # -- reservedCapacity is BETA and is enabled by default.
-        # Setting this will enable native on-demand capacity reservation support.
-        reservedCapacity: true
-        # -- spotToSpotConsolidation is ALPHA and is disabled by default.
-        # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
-        spotToSpotConsolidation: false
-        # -- staticCapacity is ALPHA and is disabled by default.
-        # Setting this to true will enable static capacity provisioning.
-        staticCapacity: false
+        # -- The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one
+        # time which usually results in fewer but larger nodes.
+        batchMaxDuration: 10s
+        # -- The maximum amount of time with no new ending pods that if exceeded ends the current batching window. If pods arrive
+        # faster than this time, the batching window will be extended up to the maxDuration. If they arrive slower, the pods
+        # will be batched separately.
+        batchIdleDuration: 1s
+        # -- How the Karpenter scheduler should treat preferences. Preferences include preferredDuringSchedulingIgnoreDuringExecution
+        # node and pod affinities/anti-affinities and ScheduleAnyways topologySpreadConstraints. Can be one of 'Ignore' and 'Respect'
+        preferencePolicy: Respect
+        # -- How the Karpenter scheduler treats min values. Options include 'Strict' (fails scheduling when min values can't be met) and 'BestEffort' (relaxes min values when they can't be met).
+        minValuesPolicy: Strict
+        # -- Cluster CA bundle for TLS configuration of provisioned nodes. If not set, this is taken from the controller's TLS configuration for the API server.
+        clusterCABundle: ""
+        # -- Cluster name.
+        clusterName: "karpenter"
+        # -- Cluster endpoint. If not set, will be discovered during startup (EKS only).
+        clusterEndpoint: ""
+        # -- If true then assume we can't reach AWS services which don't have a VPC endpoint.
+        # This also has the effect of disabling look-ups to the AWS pricing endpoint.
+        isolatedVPC: false
+        # -- Marking this true means that your cluster is running with an EKS control plane and Karpenter should attempt to discover cluster details from the DescribeCluster API.
+        eksControlPlane: false
+        # -- The VM memory overhead as a percent that will be subtracted from the total memory for all instance types. The value of `0.075` equals to 7.5%.
+        vmMemoryOverheadPercent: 0.075
+        # -- Interruption queue is the name of the SQS queue used for processing interruption events from EC2.
+        # Interruption handling is disabled if not specified. Enabling interruption handling may
+        # require additional permissions on the controller service account. Additional permissions are outlined in the docs.
+        interruptionQueue: ""
+        # -- Reserved ENIs are not included in the calculations for max-pods or kube-reserved.
+        # This is most often used in the VPC CNI custom networking setup https://docs.aws.amazon.com/eks/latest/userguide/cni-custom-network.html.
+        reservedENIs: "0"
+        # -- Ignore pods' DRA requests during scheduling simulations.
+        ignoreDRARequests: true
+        # -- Disable cluster state metrics and events.
+        disableClusterStateObservability: false
+        # -- Disable dry run validation for EC2NodeClasses.
+        disableDryRun: false
+        # -- Feature Gate configuration values. Feature Gates will follow the same graduation process and requirements as feature gates
+        # in Kubernetes. More information here https://kubernetes.io/docs/reference/command-line-tools-reference/feature-gates/#feature-gates-for-alpha-or-beta-features.
+        featureGates:
+          # -- nodeRepair is ALPHA and is disabled by default.
+          # Setting this to true will enable node repair.
+          nodeRepair: false
+          # -- nodeOverlay is ALPHA and is disabled by default.
+          # Setting this will allow the use of node overlay to impact scheduling decisions
+          nodeOverlay: false
+          # -- reservedCapacity is BETA and is enabled by default.
+          # Setting this will enable native on-demand capacity reservation support.
+          reservedCapacity: true
+          # -- spotToSpotConsolidation is ALPHA and is disabled by default.
+          # Setting this to true will enable spot replacement consolidation for both single and multi-node consolidation.
+          spotToSpotConsolidation: false
+          # -- staticCapacity is ALPHA and is disabled by default.
+          # Setting this to true will enable static capacity provisioning.
+          staticCapacity: false


### PR DESCRIPTION
## Description

This PR upgrades the **kube-karpenter** wrapper chart to **v1.10.0**, matching the upstream Karpenter OCI chart (`public.ecr.aws/karpenter`).

**Summary of changes**

- Bump chart `version` / `appVersion` and the `spec` dependency to **1.10.0** in `charts/kube-karpenter/Chart.yaml`.
- Refresh `charts/kube-karpenter/values.yaml` so wrapper defaults stay aligned with upstream (large structural sync; ~232 insertions / ~209 deletions).

**Motivation**

Bring Karpenter packaging up to date for fixes and features from the 1.10.x line.

**Dependencies**

- Upstream chart: `oci://public.ecr.aws/karpenter` at version **1.10.0**.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chart Version Update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration.

- Not run in this environment. Suggested checks: `helm dependency update` under `charts/kube-karpenter`, then `helm template` / `helm lint` with your cluster values; optional upgrade on a non-prod cluster.

## Checklist:

- [ ] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [ ] My changes generate no new warnings.
- [x] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [ ] I have tested my changes on a live Kubernetes cluster.

## Additional Information

- Commit on this branch: `f5b80cf` — `feat(charts): [karpenter] upgrade the chart to v1.10.0`.
- No root `CHANGELOG.md` was found in this repo; adjust the checklist if chart-level release notes live elsewhere.
- Branch name uses the `fest/` prefix as pushed to `origin`.

## Screenshots

N/A (Helm values and chart metadata only).

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.