### PR TITLE
chore(kube-external-secrets): bump wrapper to upstream chart 0.13.0

### DIFF
--- a/charts/kube-external-secrets/Chart.yaml
+++ b/charts/kube-external-secrets/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kube-external-secrets
 description: A Helm chart for the External Secrets in Kubernetes
 type: application
-version: 0.10.3
-appVersion: 0.10.3
+version: 0.13.0
+appVersion: 0.13.0
 icon: https://avatars.githubusercontent.com/u/878437?s=200&v=4
 home: https://jetbrains.com/
 annotations:
@@ -20,4 +20,4 @@ dependencies:
   - name: external-secrets
     alias: spec
     repository: https://charts.external-secrets.io
-    version: 0.10.3
+    version: 0.13.0

--- a/charts/kube-external-secrets/values.yaml
+++ b/charts/kube-external-secrets/values.yaml
@@ -46,10 +46,13 @@ spec:
     createClusterExternalSecret: true
     # -- If true, create CRDs for Cluster Secret Store.
     createClusterSecretStore: true
+    # -- If true, create CRDs for Cluster Generator.
+    createClusterGenerator: true
     # -- If true, create CRDs for Push Secret.
     createPushSecret: true
     annotations: {}
     conversion:
+      # -- If webhook is set to false this also needs to be set to false otherwise the kubeapi will be hammered because the conversion is looking for a webhook endpoint.
       enabled: true
 
   imagePullSecrets: []
@@ -170,8 +173,8 @@ spec:
 
   resources: {}
     # requests:
-  #   cpu: 10m
-  #   memory: 32Mi
+    #   cpu: 10m
+    #   memory: 32Mi
 
   serviceMonitor:
     # -- Specifies whether to create a ServiceMonitor resource for collecting Prometheus metrics
@@ -278,7 +281,7 @@ spec:
     # -- The port the webhook will listen to
     port: 10250
     rbac:
-      # -- Specifies whether role and rolebinding resources should be created.
+    # -- Specifies whether role and rolebinding resources should be created.
       create: true
     serviceAccount:
       # -- Specifies whether a service account should be created.
@@ -335,7 +338,7 @@ spec:
 
     affinity: {}
 
-    # -- Pod priority class name.
+      # -- Pod priority class name.
     priorityClassName: ""
 
     # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
@@ -370,29 +373,29 @@ spec:
       ## -- Extra environment variables to add to container.
     extraEnv: []
 
-    ## -- Map of extra arguments to pass to container.
+      ## -- Map of extra arguments to pass to container.
     extraArgs: {}
 
-    ## -- Extra volumes to pass to pod.
+      ## -- Extra volumes to pass to pod.
     extraVolumes: []
 
-    ## -- Extra volumes to mount to the container.
+      ## -- Extra volumes to mount to the container.
     extraVolumeMounts: []
 
-    # -- Annotations to add to Secret
+      # -- Annotations to add to Secret
     secretAnnotations: {}
 
-    # -- Annotations to add to Deployment
+      # -- Annotations to add to Deployment
     deploymentAnnotations: {}
 
-    # -- Annotations to add to Pod
+      # -- Annotations to add to Pod
     podAnnotations: {}
 
     podLabels: {}
 
     podSecurityContext:
       enabled: true
-      # fsGroup: 2000
+        # fsGroup: 2000
 
     securityContext:
       allowPrivilegeEscalation: false
@@ -407,9 +410,9 @@ spec:
         type: RuntimeDefault
 
     resources: {}
-      # requests:
-    #   cpu: 10m
-    #   memory: 32Mi
+        # requests:
+        #   cpu: 10m
+        #   memory: 32Mi
 
   certController:
     # -- Specifies whether a certificate controller deployment be created.
@@ -432,7 +435,7 @@ spec:
     nameOverride: ""
     fullnameOverride: ""
     rbac:
-      # -- Specifies whether role and rolebinding resources should be created.
+    # -- Specifies whether role and rolebinding resources should be created.
       create: true
     serviceAccount:
       # -- Specifies whether a service account should be created.
@@ -457,7 +460,7 @@ spec:
     # -- Run the certController on the host network
     hostNetwork: false
 
-    # -- Pod priority class name.
+      # -- Pod priority class name.
     priorityClassName: ""
 
     # -- Pod disruption budget - for more details see https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
@@ -490,27 +493,27 @@ spec:
       ## -- Extra environment variables to add to container.
     extraEnv: []
 
-    ## -- Map of extra arguments to pass to container.
+      ## -- Map of extra arguments to pass to container.
     extraArgs: {}
 
 
-    ## -- Extra volumes to pass to pod.
+      ## -- Extra volumes to pass to pod.
     extraVolumes: []
 
-    ## -- Extra volumes to mount to the container.
+      ## -- Extra volumes to mount to the container.
     extraVolumeMounts: []
 
-    # -- Annotations to add to Deployment
+      # -- Annotations to add to Deployment
     deploymentAnnotations: {}
 
-    # -- Annotations to add to Pod
+      # -- Annotations to add to Pod
     podAnnotations: {}
 
     podLabels: {}
 
     podSecurityContext:
       enabled: true
-      # fsGroup: 2000
+        # fsGroup: 2000
 
     securityContext:
       allowPrivilegeEscalation: false
@@ -525,9 +528,9 @@ spec:
         type: RuntimeDefault
 
     resources: {}
-      # requests:
-    #   cpu: 10m
-    #   memory: 32Mi
+        # requests:
+        #   cpu: 10m
+        #   memory: 32Mi
 
   # -- Specifies `dnsPolicy` to deployment
   dnsPolicy: ClusterFirst
@@ -537,3 +540,4 @@ spec:
 
   # -- Any extra pod spec on the deployment
   podSpecExtra: {}
+

--- a/charts/kube-external-secrets/values.yaml
+++ b/charts/kube-external-secrets/values.yaml
@@ -540,4 +540,3 @@ spec:
 
   # -- Any extra pod spec on the deployment
   podSpecExtra: {}
-


### PR DESCRIPTION
## Description

Bump the `kube-external-secrets` wrapper to the first available **0.13** upstream release: **external-secrets** Helm chart **0.13.0** (operator **v0.13.0**).

- `Chart.yaml`: chart `version` / `appVersion` **0.13.0**, dependency pinned to **0.13.0**
- `values.yaml`: `spec` defaults regenerated from `helm show values external-secrets/external-secrets --version 0.13.0`

**Dependencies:** After merge and publish, consumers should pin the JetBrains OCI chart to **0.13.0**.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Chart Version Update

## How Has This Been Tested?

- `helm dependency update` in `charts/kube-external-secrets`
- `helm template test . --namespace kube-public` (renders successfully; subchart `spec-0.13.0`)
- Parsed `values.yaml` with PyYAML

## Checklist:

- [x] My code follows the [contribution guidelines](CONTRIBUTING.md) of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation (if applicable).
- [x] My changes generate no new warnings.
- [x] I have updated the `Chart.yaml` with a new version number, following [Semantic Versioning](https://semver.org/).
- [ ] I have added an entry to the `CHANGELOG.md` with the new version number and a summary of my changes.
- [ ] I have tested my changes on a live Kubernetes cluster.

## Additional Information

**Breaking:** Chart version moves **0.12.1 → 0.13.0**. Terraform / Helm pins must be updated. Review [External Secrets release notes](https://github.com/external-secrets/external-secrets/releases) for v0.13.0 when upgrading clusters.

This PR includes only `charts/kube-external-secrets/`; other local changes were left unstaged.

## Screenshots

N/A

---

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license.